### PR TITLE
Add accounting activities and transactions endpoints

### DIFF
--- a/lib/nicehash/accounting.rb
+++ b/lib/nicehash/accounting.rb
@@ -1,5 +1,9 @@
+require 'nicehash/accounting/activities_params'
+require 'nicehash/accounting/activity'
 require 'nicehash/accounting/currency'
 require 'nicehash/accounting/total'
+require 'nicehash/accounting/transaction'
+require 'nicehash/accounting/transactions_params'
 
 module Nicehash
   module Accounting
@@ -7,15 +11,35 @@ module Nicehash
       include ExceptionEndpoints
       exception_endpoint! :fetch_currency
       exception_endpoint! :fetch_total
+      exception_endpoint! :fetch_activities
+      exception_endpoint! :fetch_transactions
 
       def fetch_currency(currency:)
         details = get.call(path: "/main/api/v2/accounting/account2/#{currency}")
         details.fmap { |details| Currency.new(details) }
       end
 
+      def fetch_activities(currency:, params: ActivitiesParams.new)
+        valid_params!(params, ActivitiesParams)
+        details = get.call(
+          path: "/main/api/v2/accounting/activity/#{currency}",
+          query: params.to_h.compact
+        )
+        details.fmap { |list| list.map { |fields| Activity.new(fields) } }
+      end
+
       def fetch_total
         total = get.call(path: '/main/api/v2/accounting/accounts2/')
         total.fmap { |total| Total.new(total) }
+      end
+
+      def fetch_transactions(currency:, params: TransactionsParams)
+        valid_params!(params, TransactionsParams)
+        transactions = get.call(
+          path: "/main/api/v2/accounting/transactions/#{currency}",
+          query: params.to_h.compact
+        )
+        transactions.fmap { |txs| txs['list'].map { |tx| Transaction.new(tx) } }
       end
     end
   end

--- a/lib/nicehash/accounting/activities_params.rb
+++ b/lib/nicehash/accounting/activities_params.rb
@@ -1,0 +1,13 @@
+module Nicehash
+  module Accounting
+    class ActivitiesParams < BaseStruct
+      attribute? :type, Types::String.enum(
+        "DEPOSIT", "WITHDRAWAL", "HASHPOWER", "MINING", "EXCHANGE",
+        "UNPAID_MINING", "OTHER"
+      )
+      attribute? :timestamp, Types.Constructor(Integer) { |v| v.to_i * 1000 }
+      attribute? :stage, Types::String.default('ALL'.freeze)
+      attribute? :limit, Types::Integer.default(10)
+    end
+  end
+end

--- a/lib/nicehash/accounting/activity.rb
+++ b/lib/nicehash/accounting/activity.rb
@@ -1,0 +1,22 @@
+module Nicehash
+  module Accounting
+    class Activity < BaseStruct
+      attribute :id, Types::Uuid
+      attribute :type, Types::String
+      attribute :time, Types::TimeInt
+      attribute :status, Types::String
+      attribute :algorithm, Types::Algorithms
+      attribute :hashPowerOrderType, Types::String
+      attribute :paidAmount, Types::FloatString
+      attribute :feeAmount, Types::FloatString
+      attribute :startTs, Types::TimeInt
+      attribute :updatedTs, Types::TimeInt
+      attribute :expiredTs, Types::TimeInt
+      attribute :estDurationInSec, Types::Coercible::Integer
+      attribute :orderLifetime, Types::Coercible::Integer
+      attribute :price, Types::FloatString
+      attribute :progress, Types::FloatString
+      attribute :pool, Types::String
+    end
+  end
+end

--- a/lib/nicehash/accounting/transaction.rb
+++ b/lib/nicehash/accounting/transaction.rb
@@ -1,0 +1,18 @@
+module Nicehash
+  module Accounting
+
+    SubEnumName = Types.Constructor(String) { |obj| obj['enumName'] }
+
+    class Transaction < BaseStruct
+      attribute :id, Types::Uuid
+      attribute :created, Types::TimeInt
+      attribute :currency, SubEnumName
+      attribute :amount, Types::FloatString
+      attribute :type, SubEnumName
+      attribute :fromOwner, Types::Uuid
+      attribute :fromAccountType, SubEnumName
+      attribute :purpose, SubEnumName
+      attribute :serviceRef, Types::Uuid
+    end
+  end
+end

--- a/lib/nicehash/accounting/transactions_params.rb
+++ b/lib/nicehash/accounting/transactions_params.rb
@@ -1,0 +1,12 @@
+module Nicehash
+  module Accounting
+    class TransactionsParams < BaseStruct
+      attribute? :type, Types::String.enum("DEPOSIT", "WITHDRAWAL", "MOVE")
+      attribute? :purposes, Types.Array(String)
+      attribute? :op, Types::String.enum("GT", "GE", "LT", "LE")
+      attribute? :timestamp, Types.Constructor(Integer) { |v| v.to_i * 1000 }
+      attribute? :page, Types::Integer.default(0)
+      attribute? :size, Types::Integer.default(10)
+    end
+  end
+end

--- a/lib/nicehash/types.rb
+++ b/lib/nicehash/types.rb
@@ -28,6 +28,7 @@ module Nicehash
     PositiveFloat = Types::Coercible::Float.constrained(gteq: 0.0)
     FloatString = Types.Constructor(Float) { |v| v.to_f }
     IntString = Types.Constructor(Integer) { |v| v.to_i }
+    TimeInt = Types.Constructor(Time) { |v| ::Time.at(v.to_i / 1000) }
   end
 
   BaseStruct = Dry.Struct { transform_keys(&:to_sym) }

--- a/spec/accounting_spec.rb
+++ b/spec/accounting_spec.rb
@@ -21,6 +21,24 @@ module Nicehash
           expect(total.currencies.size).to be > 1
         end
       end
+
+      describe '#fetch_activities(:currency, :params)' do
+        it 'returns activities for specified :currency, filtered :params' do
+          params = ActivitiesParams.new(limit: 3)
+          activities = client.fetch_activities!(currency: 'BTC', params: params)
+          expect(activities.length).to eq(3)
+          expect(activities[0]).to be_a(Accounting::Activity)
+        end
+      end
+
+      describe '#fetch_transactions(:currency, :params)' do
+        it 'returns activities for specified :currency, filtered :params' do
+          params = TransactionsParams.new(size: 3)
+          txs = client.fetch_transactions!(currency: 'BTC', params: params)
+          expect(txs.length).to eq(3)
+          expect(txs[0]).to be_a(Accounting::Transaction)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Note: Depending on which NiceHash API credentials you use, there will be one, or more, failing tests. We have two accounts, that don't have identical sets of data, matched up to the same endpoints.

This will be "fixed", once I can fully isolate the test suite, through `webmock` stubbed API returns.

@rschifflin Great work on the conversion to full monads, with `ExceptionEndpoints`. Made adding in the new endpoints, and their respective tests quite easy.